### PR TITLE
Added the archiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,41 +10,110 @@ Stochastic Gradiant Response is a type of emergent behavior characterised by a l
 
 This is different from other forms of "emergent behavior" algorithms such as the Boids algorithm (REFERENCE) or Cucker-Smale algorithm modeling actions like flocking behavior. In a flock (or school of fish), the important behavior is that the entire flock converges on a shared value, such as each bird adopting the same flight vector as the average flight vector of the flock, because the agents want both to avoid leaving the flock and also to avoid running into other birds in the flock. However, the specific vector is not important. Stochastic Gradiant Response provides and algorithm for agents to decide whether to join in a joint enterprise, _or not to join the enterprise_, in a way that ensures that resources are preferentially allocated to the highest priority tasks.
 
+## Design
+
+The kernel function represents the space the algorithm is attempting to explore. An arbitrary goal was set to try to gather as many (x, y) pairs for which the value F(x, y) is close to 0. Points for which F(x, y) is "high" (closer to 1) is considered wasted work. (TODO: I should create a report of total value, not just exploited points. Exploited points weighted by value). Exploring this space with multiple workers that do not require direction or assignment of tasks from a central authority is the goal.
+
+The major design goals of this project were
+1. demonstrate the Stochastic Gradient Response concept as clearly as possible,
+2. gather the metadata that would record the different executions of the algorithm under different metaparameters, demonstrating its ability to prioritize tasks based on their value and its behavior under different tuning conditions as transparently as possible, and
+3. record/report the data in a way that is useful for other users running the application for themselves, but is also compatible with more sophisticated data analysis tools.
+
+To these ends, I made the main datatype of the algorithm itself a tuple (BigDecimal, BigDecimal) for prospect points found by the explorers and a 3-tuple (BigDecimal, BigDecimal, BigDecimal) for points exploited, and the metadata gathered in the monad DataPoint. Points are lifted to DataPoint with the DataPoint.apply function and the metadata gathered therein is collected from implicit parameters rather than parameters of the function.
+
+Each experiment is executed out of a single experiment workspace with the experimental configuration (namely, the hyperparameters of the algorithm) defined in a configuration file called "experiment.conf" in a "config" subfolder. Each experiment has its logging output recorded in a "logs" subfolder so that different executions have their trace recorded separately. Data generated for an experiment execution are all stored in the experiment work folder to keep different executions separate. The generated data is, by default, output into a CSV file so it can be appended with other executions into a single larger dataset. (More complex data archiving may be coming soon). Each experiment can be configured to be run multiple times to create statistical significance. Each experiment execution can provide a --parent parameter to reference a folder that contains a "config" subfolder; the parent's "experiment.conf" file will provide defaults that the individual experiment folder will override. This enforces that non-overridden variables are consistent across runs intended to be comparable.
+
+To track the creation of points, all point creation is channeled through a single Pekko Actor so that all DataPoint monads are assigned sequence numbers from a single sequence. The is performed by the DataPoint.apply method outsourcing the creation of DataPoint instances to the DataPointActor.
+
+The Dispatcher represents the interface through which the various agents are created and through which the agents observe the world, but it does not assign work or play an active role in the agents' decision-making regarding their choice of work to perform. It creates a fixed number of Worker actors, each of which is responsible for spawning, monitoring, and stopping a processing thread that can either be exploring the world or exploiting points found by other agents. (These are now Futures, not threads, which seems to work better but I'm think the reporting needs updating to account for this) Each processing thread operates in one of three states: Explorer, Exploiter, or ChooseState, and each processing thread is assigned a "preference" that is generated according to the DistributionStrategy configured for the experiment.
+
+The Explorer state steps randomly around the phase space (from [0,0] and [1,1]) and executes the kernel function on its current space. If the point is sufficiently close to 0, it continues to sample in the region until it finds a point that is not sufficiently close to 0, and uses the number of points found as a measure of othe quality of the point. It then notifies the Dispatcher of a new prospect (the average location of all of the discovered points), as well as instructions on how long the point should remain in the queue. (This simulates a bee performing more repetitions of the "waggle dance" for high-quality patches of flowers to exploit) 
+
+The Exploiter state begins with a location of a prospect point. It chooses a point nearby (this is to avoid multiple exploiters who choose the same point from producing completely redundant data and simulates a bee travelling to the prospective flower patch and then choosing on-location flowers from which to gather pollen) and then runs the kernel function on a dense grid of points around that central location.
+
+The ChooseState state queries the Dispatcher for the list of prospects. The worker's preference is then consulted with regard to how long the list of prospects is; if the worker has a preference for a shorter list of prospects, the worker will choose one at random to work as an Exploiter; otherwise, the worker will become an Explorer and look for prospects. This simulates a bee exiting the hive and, if there are multiple bees performing the "waggle dance", the bee may choose to follow the directions in one dance or another, but the bee would have no way of knowing which bee has been present and performing for a long time, so it would not have any means of choosing the "best" patch. If the bee chooses to exploit, one strategy would be to follow the directions of the next bee to start a full repetition of its dance, which would effectively be random. (One unsimulated aspect of this scenario is that patches closer to the hive would be described with shorter dances, increasing the probability of being chosen by this method) (It should be noted that there isn't solid evidence that I know of that this is the algorithm followed by actual bees; I am only making the case that it _could be_ and _would work_)
+
+After the data is generated, there are two classes for post-processing: the Charter and the Archiver (these may be combined later). The Charter creates the chart objects that are both displayed in the UI component and are used to export the charts as images. (Most data visualization applications don't display scientific data very well; they primarily expect the X-axis to be categorical and to have values shared by all data series) The Archiver application exports the generated data for further analysis.
+
+The Demo class handles the various "plumbing" tasks of parsing the command-line arguments, reading the configuration file(s), establishing the logging output framework, starting the processing system, and initializing the GUI,
+
 ## Usage
+
+### Command-line Parameters
+
+experiment path
+: The first (and only) unnamed parameter ingested by the application should contain the path of the experiment folder. This should contain a folder "config" with a file "experiment.conf" containing the experiment configuration. This is the folder the data generated by the application will be written to.
+
+--runs
+: The number of runs of the experiment to run. If this is greater than 1, the experiment will run in "headless" mode and generate data separately for each "run" in a folder named "run-xxx", where "xxx" is the run number, stored inside the experiment folder. This defaults to 1.
+
+--headless
+: A boolean value whether to show the data in the GUI or not. If "--runs" is greater than 1, it will be in "headless" mode regardless of this parameter. This defaults to false.
+
+--parent
+: A path that should contain a folder "config" with a file "experiment.conf" in it that will provide default values for the hyperparameters of the algorithm.
 
 ### Parameters
 
 The application is provided at start-up with a reference to a folder that is expected to have a sub-folder named "config" that contains a properties file called "experiment.conf" in the format of the TypeSafe Configuration properties file. The following properties have meaning:
 
-eusocialcooperation.scheduler.duration:
-- The length of time to run the experiment. Required
+eusocialcooperation.scheduler.duration
+: The length of time to run the experiment. Required
 
-eusocialcooperation.scheduler.dispatcher.numWorkers:
-- The number of agents to use to explore the function. Required
+eusocialcooperation.scheduler.dispatcher.numWorkers
+: The number of agents to use to explore the function. Required
 
-eusocialcooperation.scheduler.workers.loopDelay:
-- An artificial delay introduced into the main loop of the workers. Optional, defaults to 50 ms. This is adjustable because it interacts with the variable delayPerProspect and numWorkers in establishing the probability of an agent seeing a task.
+eusocialcooperation.scheduler.workers.loopDelay
+: An artificial delay introduced into the main loop of the workers. Optional, defaults to 50 ms. This is adjustable because it interacts with the variable delayPerProspect and numWorkers in establishing the probability of an agent seeing a task.
 
-eusocialcooperation.scheduler.workers.explorer.numPointToExplore:
-- The number of points an explorer will search through before giving up if it hasn't found a prospect. Required.
+eusocialcooperation.scheduler.workers.explorer.numPointToExplore
+: The number of points an explorer will search through before giving up if it hasn't found a prospect. Required.
 
-eusocialcoooperation.scheduler.workers.explorer.threshold:
-- The threshold below which a point is considered a prospect. Required.
+eusocialcoooperation.scheduler.workers.explorer.threshold
+: The threshold below which a point is considered a prospect. Required.
 
-eusocialcoooperation.scheduler.workers.explorer.explorationRadius:
-- The distance an explorer will travel in a random direction to the next point to explore. Required.
+eusocialcoooperation.scheduler.workers.explorer.explorationRadius
+: The distance an explorer will travel in a random direction to the next point to explore. Required.
 
-eusocialcoooperation.scheduler.workers.explorer.delayPerProspect:
-- The amount of time a prospect is to remain visible to agents looking for a new task before it is dropped, per point discovered below the threshold. Required. For instance, if the explorer found 5 low spots, it will submit a prospect point that is at the average position of those 5 points, and request that the prospect remain visible for 5 * delayPerProspect.
+eusocialcoooperation.scheduler.workers.explorer.delayPerProspect
+: The amount of time a prospect is to remain visible to agents looking for a new task before it is dropped, per point discovered below the threshold. Required. For instance, if the explorer found 5 low spots, it will submit a prospect point that is at the average position of those 5 points, and request that the prospect remain visible for 5 * delayPerProspect.
 
-eusocialcooperation.scheduler.workeres.exploiter.increment:
-- The distance between points in the grid the exploiter will explore. Required.
+eusocialcooperation.scheduler.workeres.exploiter.increment
+: The distance between points in the grid the exploiter will explore. Required.
 
-eusocialcooperation.scheduler.workers.exploiter.fuzziness:
-- The upper-bound of the random offset introduced by the agent to avoid exactly duplicating the work of other agents that may have chosen this point.
-
-## Development
-
-### Design
+eusocialcooperation.scheduler.workers.exploiter.fuzziness
+: The upper-bound of the random offset introduced by the agent to avoid exactly duplicating the work of other agents that may have chosen this point.
 
 ## Project Layout
+
+The following folders are in the project:
+
+.github
+: contains the definition of the GitHub Actions that perform the continuous integration tasks for application maintenance.
+
+project
+: a folder that contains metadata about the project for the SBT build tool.
+
+src
+: contains the source code of the application. It contains the folders "main", which contains that source code of the application, and "test", which contains the source code of the unit tests.
+
+testconf
+: contains a work environment for executing some of the tests. It's possible this doesn't belong in the project.
+
+.gitignore
+: contains a list of the folders that git is supposed to ignore, such as configuration that is specific to the user's development environment (such as .vscode) and data generated during executions of the application.
+
+build.sbt
+: configuration for the build tool, SBT.
+
+README.md
+: this documentation file.
+
+run_delays_experiment.sh
+: a script to run the application in an experiment that varies the loopDelay variable. It's possible this should not be added to git.
+
+run_weights_experiment.sh
+: a script to run the application in an experiment that varies the weightPerProspect variable. It's possible this should not be added to git.
+
+run_distributions_experiment.sh
+: a script to run the application in an experiment that varies the distributions. It's possible this should not be added to git.

--- a/concat_data.sh
+++ b/concat_data.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+outputFile=$1
+file=$2
+distribution=$3
+run=$4
+
+cat $file | sed "s/\(.*\)/$distribution\t$run\t\1/" >> $outputFile

--- a/run_distributions_experiment.sh
+++ b/run_distributions_experiment.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#set -ex
+
+JAVA_HOME='/opt/homebrew/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home'
+parent="experiments/distribution"
+numRuns=10
+for experiment in $(ls "${parent}" | sed -n '/config/!p'); do
+    $JAVA_HOME/bin/java -Xmx5g '-classpath' './target/scala-3.7.4/hive-scheduler-assembly-0.1.0-SNAPSHOT.jar' '-Duser.dir=$(realpath .)' 'eusocialcooperation.scheduler.Demo' "${parent}/$experiment" --runs=$numRuns --parent="$parent/"
+    sleep 5
+done
+pointsDataHeaders=(distribution run seqnum x y z)
+prospectsHeaders=(distribution run seqnum x y)
+metadataHeaders=(distribution run seqnum type timestamp name phase parent)
+queueLengthsHeaders=(distribution run timestamp length)
+
+for file in pointsData prospects metadata queueLengths; do
+    headers="${file}Headers"
+    header=$(hdrVar="${headers}[*]"; IFS=$(printf "\t") ; echo "${!hdrVar}")
+    outputFile="${parent}/${file}Agg.csv"
+    printf "$header\n" > "$outputFile"
+    find . -regex ".*/$file.csv" | sed -e '/.*/p' -e "s/\.\/${parent/\//\/}\/\(.*\)\/run_\([0-9]\)*\/$file.csv/\1\n\2/" | xargs -n 3 ./concat_data.sh "$outputFile"
+done

--- a/src/main/scala/eusocialcooperation/scheduler/Demo.scala
+++ b/src/main/scala/eusocialcooperation/scheduler/Demo.scala
@@ -48,6 +48,7 @@ import org.jfree.chart.JFreeChart
 import org.jfree.chart3d.Chart3D
 import java.io.Closeable
 import scala.util.Using
+import eusocialcooperation.scheduler.archiver.Archiver
 
 /** The main entry point of the application. When this is started, the system is
   * constructed in 2 parts: the UI and the processing thread. The UI is
@@ -115,6 +116,7 @@ object Demo extends JFXApp3 {
     implicit val ec: scala.concurrent.ExecutionContext =
       scala.concurrent.ExecutionContext.global
 
+    // TODO: Probably should refactor the parameter parsing into a single function and pass around all the parameters in a case class or something.
     val experimentPath = this.parameters.unnamed.headOption match {
       // TODO: This is to enable the use of the code lens. It really should be provided either on the command line or as an environment variable.
       // case None => throw new IllegalArgumentException("Experiment path must be provided as the first argument.")
@@ -351,6 +353,11 @@ object Demo extends JFXApp3 {
           } else {
             createAndSaveCharts(points, prospects, queueLengths, outputPath)
           }
+
+          val archiver = Archiver(outputPath)
+          archiver.archivePointsData(points.get().toSeq)
+          archiver.archiveProspectsData(prospects.get().toSeq)
+          archiver.archiveQueueLengthData(queueLengths.get())
         }
       }
 

--- a/src/main/scala/eusocialcooperation/scheduler/archiver/Archiver.scala
+++ b/src/main/scala/eusocialcooperation/scheduler/archiver/Archiver.scala
@@ -1,0 +1,14 @@
+package eusocialcooperation.scheduler.archiver
+
+import eusocialcooperation.scheduler._
+import com.typesafe.config.Config
+
+object Archiver {
+  def apply(experimentPath: String)/*(implicit config: Config)*/: Archiver = new DefaultArchiver(experimentPath)
+}
+
+trait Archiver {
+  def archivePointsData(pointsData: Seq[DataPoint[Sample]]): Unit
+  def archiveProspectsData(prospects: Seq[DataPoint[Point]]): Unit
+  def archiveQueueLengthData(queueLengths: Seq[(Long, Int)]): Unit
+}

--- a/src/main/scala/eusocialcooperation/scheduler/archiver/DefaultArchiver.scala
+++ b/src/main/scala/eusocialcooperation/scheduler/archiver/DefaultArchiver.scala
@@ -1,0 +1,114 @@
+package eusocialcooperation.scheduler.archiver
+
+import eusocialcooperation.scheduler._
+import com.typesafe.config.Config
+import scala.util.Using
+import java.io.PrintWriter
+import java.io.Writer
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+import java.io.FileOutputStream
+
+class DefaultArchiver private[archiver] (
+    experimentPath: String,
+    pointsWriterFactory: () => Writer,
+    prospectsWriterFactory: () => Writer,
+    queueLengthWriterFactory: () => Writer,
+    metadataWriterFactory: () => Writer
+) /*(using
+    Config
+)*/
+    extends Archiver
+    with LoggingComponent {
+
+  def this(experimentPath: String) /*(using Config)*/ = {
+
+    this(
+      experimentPath,
+      () =>
+        new PrintWriter(
+          new BufferedWriter(
+            new OutputStreamWriter(
+              new FileOutputStream(s"$experimentPath/pointsData.csv")
+            )
+          )
+        ),
+      () =>
+        new PrintWriter(
+          new BufferedWriter(
+            new OutputStreamWriter(
+              new FileOutputStream(s"$experimentPath/prospects.csv")
+            )
+          )
+        ),
+      () =>
+        new PrintWriter(
+          new BufferedWriter(
+            new OutputStreamWriter(
+              new FileOutputStream(s"$experimentPath/queueLengths.csv")
+            )
+          )
+        ),
+      () =>
+        new PrintWriter(
+          new BufferedWriter(
+            new OutputStreamWriter(
+              new FileOutputStream(s"$experimentPath/metadata.csv", true)
+            )
+          )
+        )
+    )
+  }
+
+  private[archiver] def writeMetadata(typ: String, dp: DataPoint[?], writer: Writer): Unit = {
+      writer.write(
+        s"${dp.sequenceNumber}\t${typ}\t${dp.timestamp}\t${dp.actorName}\t${dp.phase}\t${dp.parent.fold("N/A")(_.sequenceNumber.toString())}\n"
+      )
+    }
+
+  override def archivePointsData(
+      pointsData: Seq[DataPoint[Sample]]
+  ): Unit = {
+    // Save points data
+    Using.resources(
+      pointsWriterFactory(),
+      metadataWriterFactory()
+    ) { (pointsWriter, metadataWriter) =>
+      pointsData.foreach { dp =>
+        pointsWriter.write(
+          s"${dp.sequenceNumber}\t${dp.value._1.toDouble}\t${dp.value._2.toDouble}\t${dp.value._3.toDouble}\n"
+        )
+        writeMetadata("points", dp, metadataWriter)
+      }
+    }
+  }
+
+  def archiveProspectsData(prospects: Seq[DataPoint[Point]]): Unit = {
+
+    Using.resources(
+      prospectsWriterFactory(),
+      metadataWriterFactory()
+    ) { (prospectsWriter, metadataWriter) =>
+      prospects.foreach { dp =>
+        prospectsWriter.write(
+          s"${dp.sequenceNumber}\t${dp.value._1.toDouble}\t${dp.value._2.toDouble}\n"
+        )
+        writeMetadata("prospects", dp, metadataWriter)
+      }
+    }
+  }
+
+  def archiveQueueLengthData(queueLengths: Seq[(Long, Int)]): Unit = {
+
+    Using.resources(
+      queueLengthWriterFactory(),
+      metadataWriterFactory()
+    ) { (queueLengthWriter, metadataWriter) =>
+      queueLengths.foreach { dp =>
+        queueLengthWriter.write(
+          s"${dp._1}\t${dp._2}\n"
+        )
+      }
+    }
+  }
+}

--- a/src/main/scala/eusocialcooperation/scheduler/distributions/DistributionStrategy.scala
+++ b/src/main/scala/eusocialcooperation/scheduler/distributions/DistributionStrategy.scala
@@ -124,7 +124,7 @@ class NormalDistributionStrategy(mean: BigDecimal, stddev: BigDecimal)
   * system to prevent a negative response curve in the low value range.
   *
   * @param scale
-  * The minimum value of the distribution. Should default to 0.
+  * The value of the randomly generated variable where above (1-scale) the function will return greater than 1.
   * @param shape
   * A positive number that determines the steepness of the distribution.
   */
@@ -133,7 +133,7 @@ class ParetoDistributionStrategy(scale: BigDecimal, shape: BigDecimal)
     extends DistributionStrategy {
   override def apply(): BigDecimal = {
     val u = Random.nextDouble()
-    // Not sure I see the point of subtracting from 1, but Copilot suggested it and I can't see any reason why it's a problem.
-    scale / math.pow(1 - u, 1 / shape.toDouble)
+    // Subtracting from 1 changes the meaning of the variables a little bit. The asymptote is vertical at x=1, and the resulting values increase as the randomly generated value gets larger (closer to 1), which is more intuitive for this application. The value of the function = 1 when x = (1 - scale).
+    scale.toDouble / math.pow(1 - u, 1 / shape.toDouble)
   }
 }

--- a/src/test/scala/eusocialcooperation/scheduler/archiver/DefaultArchiverSpec.scala
+++ b/src/test/scala/eusocialcooperation/scheduler/archiver/DefaultArchiverSpec.scala
@@ -1,0 +1,49 @@
+package eusocialcooperation.scheduler.archiver
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalamock.scalatest.MockFactory
+import java.io.StringWriter
+import eusocialcooperation.scheduler._
+
+class DefaultArchiverSpec extends AnyFunSuite with Matchers with MockFactory {
+  test("DefaultArchiver can be instantiated with a path") {
+    val archiver = new DefaultArchiver("testPath")
+    archiver shouldBe a[DefaultArchiver]
+  }
+
+  test("DefaultArchiver will write a collection of DataPoints to the specified path") {
+    val pointsWriter = StringWriter()
+    val prospectsWriter = StringWriter()
+    val metadataWriter = StringWriter()
+    val queueLengthsWriter = StringWriter()
+
+    val archiver = new DefaultArchiver("testPath", () => pointsWriter, () => prospectsWriter, () => queueLengthsWriter, () => metadataWriter)
+    val point1 = (BigDecimal(1.0), BigDecimal(2.0), BigDecimal(3.0))
+    val prospect1 = (BigDecimal(4.0), BigDecimal(5.0))
+    val dpProspect = new DataPoint(2, 100L, "actor2", DataPoint.Phase.Explorer, prospect1, None)
+    val pointsData = Seq(
+      new DataPoint(1, 0L, "actor1", DataPoint.Phase.Exploiter, point1, Some(dpProspect))
+    )
+    val prospects = Seq(
+      dpProspect
+    )
+    val queue_lengths = Seq(
+      (0L, 5),
+      (100L, 3)
+    )
+
+    archiver.archivePointsData(pointsData)
+    pointsWriter.toString should include("1\t1.0\t2.0\t3.0")
+
+    archiver.archiveProspectsData(prospects)
+    prospectsWriter.toString should include("2\t4.0\t5.0")
+
+    metadataWriter.toString should include("1\tpoints\t0\tactor1\tExploiter\t2")
+    metadataWriter.toString should include("2\tprospects\t100\tactor2\tExplorer\tN/A") 
+
+    archiver.archiveQueueLengthData(queue_lengths)  
+    queueLengthsWriter.toString should include("0\t5")
+    queueLengthsWriter.toString should include("100\t3")
+  }
+}


### PR DESCRIPTION
The default archiver writes the data of each run to a tab-separated CSV file to make it easier to concatenate the generated data into a single large dataset if desired. Additional arhchivers might be useful to archive directly to a database, but is probably overkill. To ensure compatibility, I carried out the distribution experiment all the way to uploading the data to Apache Superset and have been experimenting with reports there.